### PR TITLE
Added gpt-3.5-turbo-0125 chat model

### DIFF
--- a/src/main/java/org/mule/extension/openai/internal/types/ChatModelsValueProvider.java
+++ b/src/main/java/org/mule/extension/openai/internal/types/ChatModelsValueProvider.java
@@ -11,7 +11,7 @@ public class ChatModelsValueProvider implements ValueProvider{
 
     @Override
     public Set<Value> resolve() throws ValueResolvingException {
-        return ValueBuilder.getValuesFor("gpt-3.5-turbo", "gpt-3.5-turbo-0301");
+        return ValueBuilder.getValuesFor("gpt-3.5-turbo", "gpt-3.5-turbo-0125");
     }
     
 }


### PR DESCRIPTION
Added gpt-3.5-turbo-0125 chat model with higher accuracy at responding in requested formats and a fix for a bug which caused a text encoding issue for non-English language function calls. Returns a maximum of 4,096 output tokens.